### PR TITLE
Comment DTO  수정

### DIFF
--- a/dplanner/src/main/java/com/dp/dplanner/domain/Comment.java
+++ b/dplanner/src/main/java/com/dp/dplanner/domain/Comment.java
@@ -18,6 +18,12 @@ public class Comment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+
     private String content;
 
 


### PR DESCRIPTION
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "parent_id")
    private Comment parent; 

- 대댓글 기능을 위해 parent_id 추가 
- ManyToOne으로 한  이유는 에브리타임처럼 원본 댓글에 대해서만 대댓글을 추가하기 위함

![image](https://github.com/dpplanner/api/assets/57498298/6846f424-9497-478d-9432-786e31d71728)
