### PR TITLE
PR : cors 설정

### DIFF
--- a/dplanner/src/main/java/com/dp/dplanner/config/security/SecurityConfig.java
+++ b/dplanner/src/main/java/com/dp/dplanner/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.dp.dplanner.config.security;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -11,6 +12,12 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -19,6 +26,11 @@ public class SecurityConfig {
 
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final JwtTokenProvider tokenProvider;
+
+    // 웹(브라우저) 허용 오리진. application-*.yml의 app.cors.allowed-origins 로 콤마구분 지정.
+    // 기본값: 로컬 개발(flutter run -d chrome) 허용. 운영 웹 도메인은 yml에 추가.
+    @Value("${app.cors.allowed-origins:http://localhost:*,https://localhost:*}")
+    private String[] allowedOrigins;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -49,5 +61,21 @@ public class SecurityConfig {
         http.addFilterBefore(new JwtAuthenticationFilter(tokenProvider),
                 UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        // 패턴(*) 지원 + 자격증명 허용을 위해 AllowedOriginPatterns 사용
+        config.setAllowedOriginPatterns(Arrays.asList(allowedOrigins));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Authorization"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }


### PR DESCRIPTION
- CorsConfigurationSource 빈 추가 (기존 .cors()가 무설정이었음)
- 허용 오리진을 app.cors.allowed-origins 프로퍼티로 외부화
- 기본값 localhost (flutter run -d chrome 로컬 웹 개발 허용)
- 운영 웹 도메인은 application-production.yml에 추가