### PR TITLE
PR : 웹 전용 카카오 로그인 엔드포인트 추가 (POST /auth/login/kakao/web)

### DIFF
--- a/dplanner/src/main/java/com/dp/dplanner/adapter/controller/AuthController.java
+++ b/dplanner/src/main/java/com/dp/dplanner/adapter/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.dp.dplanner.adapter.controller;
 
 import com.dp.dplanner.adapter.dto.CommonResponse;
+import com.dp.dplanner.adapter.dto.KakaoWebLoginDto;
 import com.dp.dplanner.adapter.dto.LoginDto;
 import com.dp.dplanner.adapter.dto.LoginResponseDto;
 import com.dp.dplanner.adapter.dto.TokenDto;
@@ -46,6 +47,16 @@ public class AuthController {
     @PostMapping("/auth/login")
     public CommonResponse<LoginResponseDto> login(@RequestBody @Valid LoginDto loginDto) {
         return CommonResponse.createSuccess(authService.login(loginDto));
+    }
+
+    /**
+     * 웹 전용 카카오 로그인.
+     * 프론트(웹)가 받은 인가 코드를 서버가 카카오와 토큰 교환 후 우리 JWT 를 발급한다.
+     * 응답 형태는 기존 /auth/login 과 동일.
+     */
+    @PostMapping("/auth/login/kakao/web")
+    public CommonResponse<LoginResponseDto> kakaoWebLogin(@RequestBody @Valid KakaoWebLoginDto kakaoWebLoginDto) {
+        return CommonResponse.createSuccess(authService.loginWithKakaoWeb(kakaoWebLoginDto));
     }
 
     @PostMapping("/eula") // /auth 경로는 JwtAuthenticationFilter 타지 않기 때문에 해당 API는 /auth 접두사 붙이지 않음.

--- a/dplanner/src/main/java/com/dp/dplanner/adapter/dto/KakaoWebLoginDto.java
+++ b/dplanner/src/main/java/com/dp/dplanner/adapter/dto/KakaoWebLoginDto.java
@@ -1,0 +1,27 @@
+package com.dp.dplanner.adapter.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 웹 전용 카카오 로그인 요청.
+ * 웹은 카카오 정책상 클라이언트에서 토큰 발급이 불가하여 인가 코드만 받을 수 있으므로,
+ * 인가 코드와 redirect_uri 를 서버로 보내 서버가 토큰 교환을 수행한다.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KakaoWebLoginDto {
+
+    @NotBlank
+    private String authorizationCode;
+
+    @NotBlank
+    private String redirectUri;
+}

--- a/dplanner/src/main/java/com/dp/dplanner/exception/ErrorResult.java
+++ b/dplanner/src/main/java/com/dp/dplanner/exception/ErrorResult.java
@@ -16,6 +16,7 @@ public enum ErrorResult {
     RESERVATION_UNAVAILABLE(HttpStatus.BAD_REQUEST,"예약할 수 없는 시간입니다."),
     CLUBMEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "clubMember is already exists, request is invalid"),
     REQUEST_IS_INVALID(HttpStatus.BAD_REQUEST, "request is invalid"),
+    KAKAO_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "카카오 이메일 제공 동의가 필요합니다."),
 
 
 
@@ -23,6 +24,7 @@ public enum ErrorResult {
      * 401 - 인증되지 않음
      */
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "token is invalid."),
+    KAKAO_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "kakao login failed, request is invalid"),
 
     /**
      * 403 - 권한 없음 -> 404 (to hide resource existence, change 403 -> 404 )

--- a/dplanner/src/main/java/com/dp/dplanner/service/AuthService.java
+++ b/dplanner/src/main/java/com/dp/dplanner/service/AuthService.java
@@ -3,6 +3,7 @@ package com.dp.dplanner.service;
 import com.dp.dplanner.adapter.dto.LoginResponseDto;
 import com.dp.dplanner.domain.Member;
 import com.dp.dplanner.domain.club.ClubMember;
+import com.dp.dplanner.adapter.dto.KakaoWebLoginDto;
 import com.dp.dplanner.adapter.dto.LoginDto;
 import com.dp.dplanner.adapter.dto.TokenDto;
 import com.dp.dplanner.service.exception.ServiceException;
@@ -29,6 +30,7 @@ public class AuthService {
     private final ClubMemberRepository clubMemberRepository;
 //    private final ClubRepository clubRepository;
     private final JwtTokenProvider tokenProvider;
+    private final KakaoOAuthClient kakaoOAuthClient;
 
     @Transactional
     public TokenDto refreshToken(TokenDto tokenDto) {
@@ -54,13 +56,35 @@ public class AuthService {
     }
     @Transactional
     public LoginResponseDto login(LoginDto loginDto) {
-        String email = loginDto.getEmail();
-        String name = loginDto.getName();
+        return issueLogin(loginDto.getEmail(), loginDto.getName());
+    }
+
+    /**
+     * 웹 전용 카카오 로그인.
+     * 프론트가 받은 인가 코드를 서버가 카카오와 토큰 교환 → 사용자 정보 조회 후
+     * 기존 로그인 로직(email+name)을 재사용해 우리 JWT 를 발급한다.
+     */
+    @Transactional
+    public LoginResponseDto loginWithKakaoWeb(KakaoWebLoginDto dto) {
+        KakaoOAuthClient.KakaoUserInfo userInfo =
+                kakaoOAuthClient.getUserInfo(dto.getAuthorizationCode(), dto.getRedirectUri());
+
+        if (userInfo.email() == null || userInfo.email().isBlank()) {
+            // 카카오 이메일 미동의/비공개 시 회원 식별 불가 → 프론트가 이메일 제공 동의를 다시 받도록 유도
+            throw new ServiceException(KAKAO_EMAIL_REQUIRED);
+        }
+        String name = (userInfo.nickname() != null && !userInfo.nickname().isBlank())
+                ? userInfo.nickname() : "카카오사용자";
+
+        return issueLogin(userInfo.email(), name);
+    }
+
+    private LoginResponseDto issueLogin(String email, String name) {
         PrincipalDetails principalDetail;
         Authentication authentication;
 
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
-        Member member = optionalMember.orElseGet(() -> createMember(name,email));
+        Member member = optionalMember.orElseGet(() -> createMember(name, email));
 
         Optional<ClubMember> optionalClubMember = member.getRecentClub() != null ?
                 clubMemberRepository.findByClubIdAndMemberId(member.getRecentClub().getId(), member.getId()) :

--- a/dplanner/src/main/java/com/dp/dplanner/service/KakaoOAuthClient.java
+++ b/dplanner/src/main/java/com/dp/dplanner/service/KakaoOAuthClient.java
@@ -1,0 +1,108 @@
+package com.dp.dplanner.service;
+
+import com.dp.dplanner.service.exception.ServiceException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+import static com.dp.dplanner.exception.ErrorResult.KAKAO_LOGIN_FAILED;
+
+/**
+ * 카카오 OAuth(웹) 처리: 인가 코드 → 토큰 교환 → 사용자 정보 조회.
+ */
+@Slf4j
+@Component
+public class KakaoOAuthClient {
+
+    private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${kakao.rest-api-key:}")
+    private String restApiKey;
+
+    @Value("${kakao.client-secret:}")
+    private String clientSecret;
+
+    /**
+     * 인가 코드로 카카오 토큰을 교환하고 사용자 정보를 조회한다.
+     */
+    public KakaoUserInfo getUserInfo(String authorizationCode, String redirectUri) {
+        String accessToken = exchangeToken(authorizationCode, redirectUri);
+        return fetchUserInfo(accessToken);
+    }
+
+    private String exchangeToken(String authorizationCode, String redirectUri) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", restApiKey);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", authorizationCode);
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            params.add("client_secret", clientSecret);
+        }
+
+        try {
+            ResponseEntity<Map> response =
+                    restTemplate.postForEntity(TOKEN_URL, new HttpEntity<>(params, headers), Map.class);
+            Object token = response.getBody() != null ? response.getBody().get("access_token") : null;
+            if (token == null) {
+                log.error("Kakao token exchange returned no access_token: {}", response.getBody());
+                throw new ServiceException(KAKAO_LOGIN_FAILED);
+            }
+            return token.toString();
+        } catch (RestClientException e) {
+            log.error("Kakao token exchange failed: {}", e.getMessage());
+            throw new ServiceException(KAKAO_LOGIN_FAILED);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private KakaoUserInfo fetchUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        try {
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    USER_INFO_URL, HttpMethod.GET, new HttpEntity<>(headers), Map.class);
+            Map<String, Object> body = response.getBody();
+            if (body == null) {
+                throw new ServiceException(KAKAO_LOGIN_FAILED);
+            }
+
+            String email = null;
+            String nickname = null;
+            Object accountObj = body.get("kakao_account");
+            if (accountObj instanceof Map) {
+                Map<String, Object> account = (Map<String, Object>) accountObj;
+                Object emailObj = account.get("email");
+                email = emailObj != null ? emailObj.toString() : null;
+
+                Object profileObj = account.get("profile");
+                if (profileObj instanceof Map) {
+                    Object nicknameObj = ((Map<String, Object>) profileObj).get("nickname");
+                    nickname = nicknameObj != null ? nicknameObj.toString() : null;
+                }
+            }
+            return new KakaoUserInfo(email, nickname);
+        } catch (RestClientException e) {
+            log.error("Kakao user info request failed: {}", e.getMessage());
+            throw new ServiceException(KAKAO_LOGIN_FAILED);
+        }
+    }
+
+    public record KakaoUserInfo(String email, String nickname) {
+    }
+}

--- a/dplanner/src/main/resources/application-local.yml
+++ b/dplanner/src/main/resources/application-local.yml
@@ -57,3 +57,6 @@ logging:
 
 server:
   port: 8080
+kakao:
+  rest-api-key: ${KAKAO_REST_API_KEY:}
+  client-secret: ${KAKAO_CLIENT_SECRET:}

--- a/dplanner/src/main/resources/application-production.yml
+++ b/dplanner/src/main/resources/application-production.yml
@@ -85,3 +85,7 @@ management:
     health:
       show-details: when-authorized   # 공개 시 UP/DOWN만, 내부 컴포넌트 상세는 숨김
 
+
+kakao:
+  rest-api-key: ${KAKAO_REST_API_KEY:}
+  client-secret: ${KAKAO_CLIENT_SECRET:}


### PR DESCRIPTION
- 인가 코드 → 서버에서 카카오 토큰 교환 → 유저정보 조회 → 기존 JWT 발급 재사용
- KakaoOAuthClient 추가, KAKAO_REST_API_KEY 환경변수로 관리
- 이메일 미동의 등 방어 처리, 모바일 기존 로그인 흐름은 그대로 유지